### PR TITLE
Check parameters when that makes sense

### DIFF
--- a/src/azbelt.nim
+++ b/src/azbelt.nim
@@ -84,4 +84,5 @@ proc DllMain(hinstDLL: HINSTANCE, fdwReason: DWORD, lpvReserved: LPVOID) : BOOL 
 
 
 when isMainModule:
-  go(paramStr(1))
+  if paramCount() > 0:
+    go(paramStr(1))


### PR DESCRIPTION
Call `paramCount()` in the `when isMainModule` block to avoid a crash when loading azbelt as a DLL. Since `DllMain` calls `NimMain`, I suspect `when isMainModule` triggers, and since no parameter is passed when executed that way, a crash occurs on `go(paramStr(1))` because of an out of bound access.
This PR should fix that.